### PR TITLE
index: reference the CDN url for pbs.css

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <link rel="icon" type="image/png" href="https://ptpb.pw/static/images/ptpb-128.png" sizes="128x128" />
     <link rel="icon" type="image/png" href="https://ptpb.pw/static/images/ptpb-512.png" sizes="512x512" />
 
-    <link href="//ptpb.pw/static/css/pbs.css" type="text/css" rel="stylesheet">
+    <link href="//d34zelngniy2d8.cloudfront.net/static/css/pbs.css" type="text/css" rel="stylesheet">
     <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css" type="text/css" rel="stylesheet">
     <link href="//cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.17.37/css/bootstrap-datetimepicker.min.css" type="text/css" rel="stylesheet">
 


### PR DESCRIPTION
ptpb was recently redeployed on AWS. One of the changes, is that at least for now, `pbs.css` and a few other 'static' assets are only available via a CDN url.

This is a hackfix to apply that change here as well.
